### PR TITLE
Added Bedrock Geyser/Floodgate Support

### DIFF
--- a/src/main/java/me/codedred/playtimes/commands/Time.java
+++ b/src/main/java/me/codedred/playtimes/commands/Time.java
@@ -275,10 +275,12 @@ public class Time implements CommandExecutor {
       ChatUtil.errno(sender, ChatUtil.ChatTypes.NO_PERMISSION);
       return;
     }
+    String userPrefixRegex = Pattern.quote(Objects.requireNonNull(data.getConfig().getString("floodgate-username-prefix")));
+    String regex = "[^a-z0-9_" + userPrefixRegex + "]";
     new BukkitRunnable() {
       @Override
       public void run() {
-        Pattern p = Pattern.compile("[^a-z0-9_]", Pattern.CASE_INSENSITIVE);
+        Pattern p = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
         Matcher m = p.matcher(args[0]);
         boolean b = m.find();
 

--- a/src/main/java/me/codedred/playtimes/data/CustomConfig.java
+++ b/src/main/java/me/codedred/playtimes/data/CustomConfig.java
@@ -49,6 +49,7 @@ public class CustomConfig {
   private void checkAndAddDefaults() {
     Map<String, Object> requiredKeys = new LinkedHashMap<>();
     requiredKeys.put("prefix", "&7[&b&lPlayTimes&7]");
+    requiredKeys.put("floodgate-username-prefix", ".");
     requiredKeys.put("use-papi-placeholders", false);
 
     requiredKeys.put(

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -4,6 +4,11 @@
 # The 'prefix' configures the introductory text for 'player-not-found' and 'player-never-joined' notifications.
 prefix: "&7[&b&lPlayTimes&7]"
 
+# Only for servers running Floodgate for Bedrock Geyser support.
+# This should be the same username-prefix found in your Floodgate config.yml
+# Use '' for an empty prefix
+floodgate-username-prefix: "."
+
 # Placeholder API Configuration
 # Activate this only if using PlaceholderAPI with PlayTimes.
 # To integrate PlayTimes placeholders into other plugins, simply install PlaceholderAPI; integration occurs seamlessly.

--- a/src/main/resources/exampleConfig.yml
+++ b/src/main/resources/exampleConfig.yml
@@ -4,6 +4,11 @@
 # The 'prefix' configures the introductory text for 'player-not-found' and 'player-never-joined' notifications.
 prefix: "&7[&b&lPlayTimes&7]"
 
+# Only for servers running Floodgate for Bedrock Geyser support.
+# This should be the same username-prefix found in your Floodgate config.yml
+# Use '' for an empty prefix
+floodgate-username-prefix: "."
+
 # Placeholder API Configuration
 # Activate this only if using PlaceholderAPI with PlayTimes.
 # To integrate PlayTimes placeholders into other plugins, simply install PlaceholderAPI; integration occurs seamlessly.


### PR DESCRIPTION
### Changes
- Added the ability to specify Floodgate's username prefix in config with comments
- Added that prefix to the regex when handling other players
- Added the respective key-value pair

This addresses [issue #15](https://github.com/CodedRed-Spigot/PlayTimes/issues/15) and [issue #45 ](https://github.com/CodedRed-Spigot/PlayTimes/issues/45) for Geyser incompatibility. 

**Details:**
The issue in both cases is caused by Floodgate (used in conjunction with Geyser as it's required to join Online servers) adding a prefix to bedrock usernames using an illegal character for Java usernames. This character is added to avoid username overlap conflicts and by default is set to "." but can be configured to be any (recommended non-alphanumeric) character. The regex in commands/Time.java:281 was returning Player Not Found if a non-alphanumeric character was used. The changes I've made address this and add the ability to configure the prefix to match what the users have in Floodgate.

I've tested the changes to ensure it was working for these players and will accept any character that Floodgate can use without issue. I've also ensured that users wouldn't have problems updating to this version as the config will now add the floodgate-username-prefix if it doesn't already exist.